### PR TITLE
Gerrit alias 'approve' removed since Gerrit 2.8

### DIFF
--- a/gerrithudsontrigger/src/main/java/com/sonyericsson/hudson/plugins/gerrit/trigger/config/Config.java
+++ b/gerrithudsontrigger/src/main/java/com/sonyericsson/hudson/plugins/gerrit/trigger/config/Config.java
@@ -210,23 +210,23 @@ public class Config implements IGerritHudsonTriggerConfig {
 
         gerritVerifiedCmdBuildStarted = formData.optString(
                 "gerritVerifiedCmdBuildStarted",
-                "gerrit approve <CHANGE>,<PATCHSET> --message 'Build Started <BUILDURL> <STARTED_STATS>' "
+                "gerrit review <CHANGE>,<PATCHSET> --message 'Build Started <BUILDURL> <STARTED_STATS>' "
                         + "--verified <VERIFIED> --code-review <CODE_REVIEW>");
         gerritVerifiedCmdBuildFailed = formData.optString(
                 "gerritVerifiedCmdBuildFailed",
-                "gerrit approve <CHANGE>,<PATCHSET> --message 'Build Failed <BUILDS_STATS>' "
+                "gerrit review <CHANGE>,<PATCHSET> --message 'Build Failed <BUILDS_STATS>' "
                         + "--verified <VERIFIED> --code-review <CODE_REVIEW>");
         gerritVerifiedCmdBuildSuccessful = formData.optString(
                 "gerritVerifiedCmdBuildSuccessful",
-                "gerrit approve <CHANGE>,<PATCHSET> --message 'Build Successful <BUILDS_STATS>' "
+                "gerrit review <CHANGE>,<PATCHSET> --message 'Build Successful <BUILDS_STATS>' "
                         + "--verified <VERIFIED> --code-review <CODE_REVIEW>");
         gerritVerifiedCmdBuildUnstable = formData.optString(
                 "gerritVerifiedCmdBuildUnstable",
-                "gerrit approve <CHANGE>,<PATCHSET> --message 'Build Unstable <BUILDS_STATS>' "
+                "gerrit review <CHANGE>,<PATCHSET> --message 'Build Unstable <BUILDS_STATS>' "
                         + "--verified <VERIFIED> --code-review <CODE_REVIEW>");
         gerritVerifiedCmdBuildNotBuilt = formData.optString(
                 "gerritVerifiedCmdBuildNotBuilt",
-                "gerrit approve <CHANGE>,<PATCHSET> --message 'No Builds Executed <BUILDS_STATS>' "
+                "gerrit review <CHANGE>,<PATCHSET> --message 'No Builds Executed <BUILDS_STATS>' "
                         + "--verified <VERIFIED> --code-review <CODE_REVIEW>");
         gerritFrontEndUrl = formData.optString(
                 "gerritFrontEndUrl",

--- a/gerrithudsontrigger/src/test/java/com/sonyericsson/hudson/plugins/gerrit/trigger/config/ConfigTest.java
+++ b/gerrithudsontrigger/src/test/java/com/sonyericsson/hudson/plugins/gerrit/trigger/config/ConfigTest.java
@@ -44,15 +44,15 @@ public class ConfigTest {
      */
     @Test
     public void testSetValues() {
-        String formString = "{\"gerritVerifiedCmdBuildFailed\":\"gerrit approve <CHANGE>,<PATCHSET> "
+        String formString = "{\"gerritVerifiedCmdBuildFailed\":\"gerrit review <CHANGE>,<PATCHSET> "
                 + "--message 'Failed misserably <BUILDURL>' --verified <VERIFIED> --code-review <CODE_REVIEW>\","
-                + "\"gerritVerifiedCmdBuildStarted\":\"gerrit approve <CHANGE>,<PATCHSET> "
+                + "\"gerritVerifiedCmdBuildStarted\":\"gerrit review <CHANGE>,<PATCHSET> "
                 + "--message 'Started yay!! <BUILDURL>' --verified <VERIFIED> --code-review <CODE_REVIEW>\","
-                + "\"gerritVerifiedCmdBuildSuccessful\":\"gerrit approve <CHANGE>,<PATCHSET>"
+                + "\"gerritVerifiedCmdBuildSuccessful\":\"gerrit review <CHANGE>,<PATCHSET>"
                 + " --message 'Successful wonderful <BUILDURL>' --verified <VERIFIED> --code-review <CODE_REVIEW>\","
-                + "\"gerritVerifiedCmdBuildUnstable\":\"gerrit approve <CHANGE>,<PATCHSET> "
+                + "\"gerritVerifiedCmdBuildUnstable\":\"gerrit review <CHANGE>,<PATCHSET> "
                 + "--message 'Unstable and you are to <BUILDURL>' --verified <VERIFIED> --code-review <CODE_REVIEW>\","
-                + "\"gerritVerifiedCmdBuildNotBuilt\":\"gerrit approve <CHANGE>,<PATCHSET> "
+                + "\"gerritVerifiedCmdBuildNotBuilt\":\"gerrit review <CHANGE>,<PATCHSET> "
                 + "--message 'You are not built for it <BUILDURL>' --verified <VERIFIED> --code-review <CODE_REVIEW>\","
                 + "\"gerritAuthKeyFile\":\"/home/local/gerrit/.ssh/id_rsa\","
                 + "\"gerritAuthKeyFilePassword\":\"passis\","
@@ -74,19 +74,19 @@ public class ConfigTest {
                 + "\"numberOfReceivingWorkerThreads\":\"6\"}";
         JSONObject form = (JSONObject)JSONSerializer.toJSON(formString);
         Config config = new Config(form);
-        assertEquals("gerrit approve <CHANGE>,<PATCHSET> "
+        assertEquals("gerrit review <CHANGE>,<PATCHSET> "
                 + "--message 'Failed misserably <BUILDURL>' --verified <VERIFIED> --code-review <CODE_REVIEW>",
                      config.getGerritCmdBuildFailed());
-        assertEquals("gerrit approve <CHANGE>,<PATCHSET> "
+        assertEquals("gerrit review <CHANGE>,<PATCHSET> "
                 + "--message 'Started yay!! <BUILDURL>' --verified <VERIFIED> --code-review <CODE_REVIEW>",
                      config.getGerritCmdBuildStarted());
-        assertEquals("gerrit approve <CHANGE>,<PATCHSET>"
+        assertEquals("gerrit review <CHANGE>,<PATCHSET>"
                 + " --message 'Successful wonderful <BUILDURL>' --verified <VERIFIED> --code-review <CODE_REVIEW>",
                      config.getGerritCmdBuildSuccessful());
-        assertEquals("gerrit approve <CHANGE>,<PATCHSET> "
+        assertEquals("gerrit review <CHANGE>,<PATCHSET> "
                 + "--message 'Unstable and you are to <BUILDURL>' --verified <VERIFIED> --code-review <CODE_REVIEW>",
                      config.getGerritCmdBuildUnstable());
-        assertEquals("gerrit approve <CHANGE>,<PATCHSET> "
+        assertEquals("gerrit review <CHANGE>,<PATCHSET> "
                 + "--message 'You are not built for it <BUILDURL>' --verified <VERIFIED> --code-review <CODE_REVIEW>",
                      config.getGerritCmdBuildNotBuilt());
         assertEquals(new File("/home/local/gerrit/.ssh/id_rsa").getPath(),

--- a/gerrithudsontrigger/src/test/java/com/sonyericsson/hudson/plugins/gerrit/trigger/spec/BackCompat252HudsonTest.java
+++ b/gerrithudsontrigger/src/test/java/com/sonyericsson/hudson/plugins/gerrit/trigger/spec/BackCompat252HudsonTest.java
@@ -82,7 +82,7 @@ public class BackCompat252HudsonTest extends HudsonTestCase {
         server = SshdServerMock.getInstance();
         server.returnCommandFor("gerrit ls-projects", SshdServerMock.EofCommandMock.class);
         server.returnCommandFor(GERRIT_STREAM_EVENTS, SshdServerMock.CommandMock.class);
-        server.returnCommandFor("gerrit approve.*", SshdServerMock.EofCommandMock.class);
+        server.returnCommandFor("gerrit review.*", SshdServerMock.EofCommandMock.class);
         server.returnCommandFor("gerrit version", SshdServerMock.EofCommandMock.class);
         super.setUp();
     }

--- a/gerrithudsontrigger/src/test/java/com/sonyericsson/hudson/plugins/gerrit/trigger/spec/SpecGerritTriggerHudsonTest.java
+++ b/gerrithudsontrigger/src/test/java/com/sonyericsson/hudson/plugins/gerrit/trigger/spec/SpecGerritTriggerHudsonTest.java
@@ -74,7 +74,7 @@ import com.sonyericsson.hudson.plugins.gerrit.trigger.mock.SshdServerMock;
  */
 public class SpecGerritTriggerHudsonTest extends HudsonTestCase {
 
-    //TODO Fix the SshdServerMock so that asserts can be done on approve commands.
+    //TODO Fix the SshdServerMock so that asserts can be done on review commands.
 
     /**
      * The stream-events command.
@@ -91,12 +91,12 @@ public class SpecGerritTriggerHudsonTest extends HudsonTestCase {
         server = SshdServerMock.getInstance();
         server.returnCommandFor("gerrit ls-projects", SshdServerMock.EofCommandMock.class);
         server.returnCommandFor(GERRIT_STREAM_EVENTS, SshdServerMock.CommandMock.class);
-        server.returnCommandFor("gerrit approve.*", SshdServerMock.EofCommandMock.class);
+        server.returnCommandFor("gerrit review.*", SshdServerMock.EofCommandMock.class);
         server.returnCommandFor("gerrit version", SshdServerMock.EofCommandMock.class);
         super.setUp();
         Hudson.getInstance().getPluginCenter().doInstallPlugin(GerritProject.class.getCanonicalName());
         System.out.println(Hudson.getInstance().getPluginCenter().getInstalledPlugins());
-        
+
     }
 
     @Override
@@ -283,7 +283,7 @@ public class SpecGerritTriggerHudsonTest extends HudsonTestCase {
     public void testDoubleTriggeredOnCommentAdded() throws Exception {
     	Hudson h = Hudson.getInstance();
     	WebClient wc = createWebClient();
-    	
+
         PluginImpl.getInstance().getConfig().setCategories(Setup.createCodeReviewVerdictCategoryList());
         FreeStyleProject project = DuplicatesUtil.createGerritTriggeredJobForCommentAdded(this, "projectX");
         project.getBuildersList().add(new SleepBuilder(2000));

--- a/gerrithudsontrigger/src/test/java/com/sonyericsson/hudson/plugins/gerrit/trigger/spec/gerritnotifier/SpecGerritVerifiedSetterTest.java
+++ b/gerrithudsontrigger/src/test/java/com/sonyericsson/hudson/plugins/gerrit/trigger/spec/gerritnotifier/SpecGerritVerifiedSetterTest.java
@@ -98,14 +98,14 @@ public class SpecGerritVerifiedSetterTest {
 
         IGerritHudsonTriggerConfig config = mock(IGerritHudsonTriggerConfig.class);
 
-        String parameterString = "gerrit approve MSG=OK VERIFIED=<VERIFIED> CODEREVIEW=<CODE_REVIEW>";
+        String parameterString = "gerrit review MSG=OK VERIFIED=<VERIFIED> CODEREVIEW=<CODE_REVIEW>";
         when(config.getGerritCmdBuildSuccessful()).thenReturn(parameterString);
         when(config.getGerritBuildSuccessfulVerifiedValue()).thenReturn(1);
         when(config.getGerritBuildSuccessfulCodeReviewValue()).thenReturn(1);
 
         GerritNotifier notifier = new GerritNotifier(config, mockGerritCmdRunner, hudson);
         notifier.buildCompleted(memory.getMemoryImprint(event), taskListener);
-        String parameterStringExpected = "gerrit approve MSG=OK VERIFIED=1 CODEREVIEW=1";
+        String parameterStringExpected = "gerrit review MSG=OK VERIFIED=1 CODEREVIEW=1";
 
         verify(mockGerritCmdRunner).sendCommand(parameterStringExpected);
     }
@@ -149,14 +149,14 @@ public class SpecGerritVerifiedSetterTest {
 
         IGerritHudsonTriggerConfig config = mock(IGerritHudsonTriggerConfig.class);
 
-        String parameterString = "gerrit approve MSG=Failed VERIFIED=<VERIFIED> CODEREVIEW=<CODE_REVIEW>";
+        String parameterString = "gerrit review MSG=Failed VERIFIED=<VERIFIED> CODEREVIEW=<CODE_REVIEW>";
         when(config.getGerritCmdBuildFailed()).thenReturn(parameterString);
         when(config.getGerritBuildFailedVerifiedValue()).thenReturn(-1);
         when(config.getGerritBuildFailedCodeReviewValue()).thenReturn(-1);
 
         GerritNotifier notifier = new GerritNotifier(config, mockGerritCmdRunner, hudson);
         notifier.buildCompleted(memory.getMemoryImprint(event), taskListener);
-        String parameterStringExpected = "gerrit approve MSG=Failed VERIFIED=-1 CODEREVIEW=-1";
+        String parameterStringExpected = "gerrit review MSG=Failed VERIFIED=-1 CODEREVIEW=-1";
 
         verify(mockGerritCmdRunner).sendCommand(parameterStringExpected);
     }
@@ -213,7 +213,7 @@ public class SpecGerritVerifiedSetterTest {
 
         IGerritHudsonTriggerConfig config = mock(IGerritHudsonTriggerConfig.class);
 
-        String parameterString = "gerrit approve MSG=FAILED VERIFIED=<VERIFIED> CODEREVIEW=<CODE_REVIEW>";
+        String parameterString = "gerrit review MSG=FAILED VERIFIED=<VERIFIED> CODEREVIEW=<CODE_REVIEW>";
         when(config.getGerritCmdBuildFailed()).thenReturn(parameterString);
         when(config.getGerritBuildSuccessfulVerifiedValue()).thenReturn(1);
         when(config.getGerritBuildSuccessfulCodeReviewValue()).thenReturn(1);
@@ -222,7 +222,7 @@ public class SpecGerritVerifiedSetterTest {
 
         GerritNotifier notifier = new GerritNotifier(config, mockGerritCmdRunner, hudson);
         notifier.buildCompleted(memory.getMemoryImprint(event), taskListener);
-        String parameterStringExpected = "gerrit approve MSG=FAILED VERIFIED=-1 CODEREVIEW=-1";
+        String parameterStringExpected = "gerrit review MSG=FAILED VERIFIED=-1 CODEREVIEW=-1";
 
         verify(mockGerritCmdRunner).sendCommand(parameterStringExpected);
     }


### PR DESCRIPTION
We should be using the 'review' api instead since 'approve' was just an
alias and removed since Gerrit 2.8.
